### PR TITLE
fix for runner to allow turning off code running

### DIFF
--- a/library/src/setup_runners.ts
+++ b/library/src/setup_runners.ts
@@ -11,9 +11,10 @@ export function setupRunners() {
     window.addEventListener("load", function () {
         document
             .querySelectorAll(
-                ".language-typescript.highlighter-rouge,.language-tsx.highlighter-rouge",
+                ".language-typescript.highlighter-rouge:not(.no-run),.language-tsx.highlighter-rouge:not(.no-run)",
             )
             .forEach((area) => {
+                console.log(area.className)
                 const editButton = document.createElement("button");
                 editButton.classList.add("btn", "btn-primary");
                 editButton.appendChild(document.createTextNode("✏️"));


### PR DESCRIPTION
Recognizes the class "no-run" to disable code runner on a typescript block.
<pre>
```typescript
some code
```
{: .no-run}
</pre>

To disable code runner for that block without effecting highlighting.