### PR TITLE
docs(composition): fix lemmon typo in FruitBasket

### DIFF
--- a/source/text/5-composition-inheritance/composition.md
+++ b/source/text/5-composition-inheritance/composition.md
@@ -106,7 +106,7 @@ let basket: FruitBasket = new FruitBasket(
     [
         new Fruit("apple", "red", 0.5),
         new Fruit("orange", "orange", 0.92),
-        new Fruit("lemmon", "yellow", 1.5),
+        new Fruit("lemon", "yellow", 1.5),
     ],
     4.0
 );


### PR DESCRIPTION
## Summary

Closes #133. The Composition Chapter's FruitBasket code example at `source/text/5-composition-inheritance/composition.md:109` constructed the third fruit as `new Fruit("lemmon", "yellow", 1.5)` - the citrus's name spelled with one m too many. The chapter narrative references the fruit as "lemon", and the surrounding `apple` and `orange` entries spell their names correctly. Replace `lemmon` with `lemon`.

## Why this matters

The textbook is a learning surface; learners reading the page (and especially those copy-pasting the snippet into a TypeScript playground) inherit the misspelling. The fruit name is a string literal, so the typo doesn't break the example, but it teaches a sloppy variable to readers in a chapter whose whole point is clean composition modeling.

## How to test

```
$ grep -n "lemmon" source/text/5-composition-inheritance/composition.md
(empty)
$ grep -n "lemon" source/text/5-composition-inheritance/composition.md
109:        new Fruit("lemon", "yellow", 1.5),
```

Fixes #133

AI-assisted.
