### PR TITLE
fix: correct typo 'lemmon' → 'lemon' in composition.md

### DIFF
--- a/source/text/5-composition-inheritance/composition.md
+++ b/source/text/5-composition-inheritance/composition.md
@@ -106,7 +106,7 @@ let basket: FruitBasket = new FruitBasket(
     [
         new Fruit("apple", "red", 0.5),
         new Fruit("orange", "orange", 0.92),
-        new Fruit("lemmon", "yellow", 1.5),
+        new Fruit("lemon", "yellow", 1.5),
     ],
     4.0
 );


### PR DESCRIPTION
Closing in favor of PR #139 which fixes all 4 textbook typos in one comprehensive PR.